### PR TITLE
do not include in global namespace

### DIFF
--- a/lib/uploadcare/rails/engine.rb
+++ b/lib/uploadcare/rails/engine.rb
@@ -17,7 +17,7 @@ module Uploadcare
         ActiveSupport.on_load :action_view do
           require 'uploadcare/rails/action_view/include_tags'
           require 'uploadcare/rails/action_view/uploader_tags'
-          
+
           # Simple Form helpers
           require 'uploadcare/rails/simple_form/simple_form' if defined?(SimpleForm)
 

--- a/lib/uploadcare/rails/objects/file.rb
+++ b/lib/uploadcare/rails/objects/file.rb
@@ -1,5 +1,3 @@
-include ActionView::Helpers::AssetTagHelper
-
 module Uploadcare
   module Rails
     class File < Uploadcare::Api::File

--- a/lib/uploadcare/rails/objects/group.rb
+++ b/lib/uploadcare/rails/objects/group.rb
@@ -1,5 +1,3 @@
-include ActionView::Helpers::AssetTagHelper
-
 module Uploadcare
   module Rails
     class Group < Uploadcare::Api::Group


### PR DESCRIPTION
I tried to understand what is broken in #21 and noticed you made `include` in global namespace. 

Please don't do it as it makes `Object` class dirty.

I removed these lines and it looks like all works without them.