### PR TITLE
only store/delete file if file is present

### DIFF
--- a/lib/uploadcare/rails/active_record/has_file.rb
+++ b/lib/uploadcare/rails/active_record/has_file.rb
@@ -13,8 +13,8 @@ module Uploadcare
           false
         end
 
-        define_method "build_file" do
-          cdn_url = attributes[attribute.to_s].to_s
+        define_method "build_file" do |attr_name|
+          cdn_url = attributes[attr_name.to_s].to_s
           return nil if cdn_url.empty?
 
           api = ::Rails.application.config.uploadcare.api
@@ -46,7 +46,7 @@ module Uploadcare
           # else
           #   file = Uploadcare::Rails::File.new api, cdn_url
           # end
-          build_file
+          build_file(attribute)
         end
 
         define_method "check_#{attribute}_for_uuid" do
@@ -58,7 +58,7 @@ module Uploadcare
         end
 
         define_method "store_#{attribute}" do
-          file = build_file
+          file = build_file(attribute)
 
           begin
             file.store
@@ -72,7 +72,7 @@ module Uploadcare
         end
 
         define_method "delete_#{attribute}" do
-          file = build_file
+          file = build_file(attribute)
 
           begin
             file.delete

--- a/lib/uploadcare/rails/active_record/has_file.rb
+++ b/lib/uploadcare/rails/active_record/has_file.rb
@@ -90,9 +90,13 @@ module Uploadcare
         # group url or uuid should raise an erorr
         before_save "check_#{attribute}_for_uuid"
 
-        after_save "store_#{attribute}" if UPLOADCARE_SETTINGS.store_after_save
+        if UPLOADCARE_SETTINGS.store_after_save
+          after_save "store_#{attribute}", if: Proc.new{ |obj| obj.send(attribute).present? }
+        end
 
-        after_destroy "delete_#{attribute}" if UPLOADCARE_SETTINGS.delete_after_destroy
+        if UPLOADCARE_SETTINGS.delete_after_destroy
+          after_destroy "delete_#{attribute}", if: Proc.new{ |obj| obj.send(attribute).present? }
+        end
       end
     end
   end

--- a/lib/uploadcare/rails/active_record/has_file.rb
+++ b/lib/uploadcare/rails/active_record/has_file.rb
@@ -64,7 +64,7 @@ module Uploadcare
             file.store
             ::Rails.cache.write(file.cdn_url, file.marshal_dump) if UPLOADCARE_SETTINGS.cache_files
           rescue Exception => e
-            logger.error "\nError while saving a file #{cdn_url}: #{e.class} (#{e.message}):"
+            logger.error "\nError while saving a file: #{e.class} (#{e.message}):"
             logger.error "#{::Rails.backtrace_cleaner.clean(e.backtrace).join("\n ")}"
           end
 

--- a/spec/models/has_file_spec.rb
+++ b/spec/models/has_file_spec.rb
@@ -44,4 +44,18 @@ describe :has_uploadcare_file do
     @post.destroy
     @post.file.deleted?.should == true
   end
+
+  describe :without_file_present do
+    before :each do
+      @post = Post.new title: "Post title", file: nil
+    end
+
+    it "should not try to store file if one is not present" do
+      expect(@post).to_not have_received(:store_file)
+    end
+
+    it "should not try to delete file if one is not present" do
+      expect(@post).to_not have_received(:delete_file)
+    end
+  end
 end


### PR DESCRIPTION
I'm having an issue where a model that doesn't require a file is failing on save/delete. Here is my model:

```
class State < ActiveRecord::Base
  has_uploadcare_file :image
end
```

And the error:

```
irb(main):004:0* State.create(name: "Test", abbreviation: "te")
D, [2015-06-03T22:25:42.872577 #50745] DEBUG -- :    (0.4ms)  ROLLBACK
NameError: undefined local variable or method `cdn_url' for #<State:0x007f9d077bb9b0>
    from /Users/jorgevaldivia/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/activemodel-4.1.9/lib/active_model/attribute_methods.rb:435:in `method_missing'
    from /Users/jorgevaldivia/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/activerecord-4.1.9/lib/active_record/attribute_methods.rb:213:in `method_missing'
    from /Users/jorgevaldivia/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/uploadcare-rails-1.0.6/lib/uploadcare/rails/active_record/has_file.rb:67:in `rescue in block in has_uploadcare_file'
    from /Users/jorgevaldivia/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/uploadcare-rails-1.0.6/lib/uploadcare/rails/active_record/has_file.rb:63:in `block in has_uploadcare_file'
...
```

I added a check to make sure that the file is present before storing or removing it, along with a couple of specs. Though I admit that I may be doing something wrong, so any input is appreciated. Thanks in advance!
