### PR TITLE
fix bug when file is not set

### DIFF
--- a/lib/uploadcare/rails/active_record/has_file.rb
+++ b/lib/uploadcare/rails/active_record/has_file.rb
@@ -61,12 +61,13 @@ module Uploadcare
 
         define_method "delete_#{ attribute }" do
           file = build_file
+          return if file.nil?
 
           begin
             file.delete
             ::Rails.cache.write(file.cdn_url, file.marshal_dump) if UPLOADCARE_SETTINGS.cache_files
           rescue Exception => e
-            logger.error "\nError while deleting a file #{cdn_url}: #{e.class} (#{e.message}):"
+            logger.error "\nError while deleting a file #{file.cdn_url}: #{e.class} (#{e.message}):"
             logger.error "#{::Rails.backtrace_cleaner.clean(e.backtrace).join("\n ")}"
           end
 


### PR DESCRIPTION
There was a two-layer exception because a) the file was nil, and b) the rescue referenced a nonexistent method.
