### PR TITLE
Fix failing travis build

### DIFF
--- a/uploadcare-rails.gemspec
+++ b/uploadcare-rails.gemspec
@@ -29,6 +29,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency "uploadcare-ruby", "~> 1.0"
 
   gem.add_development_dependency 'bundler', '~> 1.6'
+  # rake >= 12.0 doesn't work with rspec-core < 3.4.4
+  gem.add_development_dependency 'rake', '~> 11.1'
   gem.add_development_dependency "sqlite3"
   gem.add_development_dependency 'rspec', "~> 2"
   gem.add_development_dependency 'rspec-rails'


### PR DESCRIPTION
Build was failing because of the `listen` gem, which is a dependency of a `guard-rails` gem. With a release of bundler v14 (20.01.2017) there is no version conflict anymore. This problem won't affect users because guard-rails is a development dependency.

Also with a release of rake v12 a new problem has appeared: rake v12 doesn't work with rspec-core < 3.4.4. rake is also a dev dependency, so I fixed it by simply limiting its' version to ~> 11.1