### PR TITLE
Fix failing spec

### DIFF
--- a/spec/objects/group_spec.rb
+++ b/spec/objects/group_spec.rb
@@ -44,7 +44,7 @@ describe Uploadcare::Rails::Group, :vcr do
     it 'builds images url' do
       expect(subject.urls(size: '200x200').first).
         to eq(
-          "https://ucarecdn.com/#{ subject.uuid }/nth/0/-/resize/200x200/"
+          "#{UPLOADCARE_SETTINGS.static_url_base}/#{ subject.uuid }/nth/0/-/resize/200x200/"
         )
     end
   end

--- a/spec/objects/group_spec.rb
+++ b/spec/objects/group_spec.rb
@@ -42,10 +42,10 @@ describe Uploadcare::Rails::Group, :vcr do
     end
 
     it 'builds images url' do
-      expect(subject.urls(size: '200x200').first).
-        to eq(
-          "#{UPLOADCARE_SETTINGS.static_url_base}/#{ subject.uuid }/nth/0/-/resize/200x200/"
-        )
+      allow_any_instance_of(Uploadcare::Api).to receive(:options) { {static_url_base: 'http://example.com'} }
+      expected = "http://example.com/#{ subject.uuid }/nth/0/-/resize/200x200/"
+
+      expect(subject.urls(size: '200x200').first).to eq(expected)
     end
   end
 end

--- a/spec/objects/group_spec.rb
+++ b/spec/objects/group_spec.rb
@@ -44,7 +44,7 @@ describe Uploadcare::Rails::Group, :vcr do
     it 'builds images url' do
       expect(subject.urls(size: '200x200').first).
         to eq(
-          "http://www.ucarecdn.com/#{ subject.uuid }/nth/0/-/resize/200x200/"
+          "https://ucarecdn.com/#{ subject.uuid }/nth/0/-/resize/200x200/"
         )
     end
   end


### PR DESCRIPTION
`Uploadcare::Rails::Group images workaround builds images url` was failing from the hardcoded `http://www` URL.