### PR TITLE
Change callback generation to use symbols instead of strings

### DIFF
--- a/lib/uploadcare/rails/active_record/has_file.rb
+++ b/lib/uploadcare/rails/active_record/has_file.rb
@@ -76,11 +76,11 @@ module Uploadcare
         # before saving we checking what it is a actually file cdn url
         # or uuid. uuid will do.
         # group url or uuid should raise an erorr
-        before_save "check_#{attribute}_for_uuid"
+        before_save :"check_#{attribute}_for_uuid"
 
-        after_save "store_#{attribute}" if UPLOADCARE_SETTINGS.store_after_save
+        after_save :"store_#{attribute}" if UPLOADCARE_SETTINGS.store_after_save
 
-        after_destroy "delete_#{attribute}" if UPLOADCARE_SETTINGS.delete_after_destroy
+        after_destroy :"delete_#{attribute}" if UPLOADCARE_SETTINGS.delete_after_destroy
       end
     end
   end

--- a/lib/uploadcare/rails/active_record/has_group.rb
+++ b/lib/uploadcare/rails/active_record/has_group.rb
@@ -71,11 +71,11 @@ module Uploadcare
         # before saving we checking what it is a actually file cdn url
         # or uuid. uuid will do.
         # group url or uuid should raise an erorr
-        before_save "check_#{ attribute }_for_uuid"
+        before_save :"check_#{ attribute }_for_uuid"
 
-        after_save "store_#{ attribute }" if UPLOADCARE_SETTINGS.store_after_save
+        after_save :"store_#{ attribute }" if UPLOADCARE_SETTINGS.store_after_save
 
-        after_destroy "delete_#{ attribute }" if UPLOADCARE_SETTINGS.delete_after_destroy
+        after_destroy :"delete_#{ attribute }" if UPLOADCARE_SETTINGS.delete_after_destroy
       end
     end
   end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.


### PR DESCRIPTION
In Rails 5.1.0.beta1 passing a string to create a callback was deprecated. It's moved past deprecation and not throws an ArgumentError.

I've changed the callback generation to use symbols instead of strings.

See: https://github.com/rails/rails/blob/master/activesupport/lib/active_support/callbacks.rb#L283