### PR TITLE
Fix for config generator failling

### DIFF
--- a/lib/uploadcare/rails/settings.rb
+++ b/lib/uploadcare/rails/settings.rb
@@ -34,7 +34,7 @@ module Uploadcare
 
       def initialize(config)
         # extract envaroments settings
-        settings = config[::Rails.env]
+        settings = config[::Rails.env.to_sym]
         unless settings.present?
           raise ArgumentError, 'config is empty or not given at all'
         end


### PR DESCRIPTION
Rails.env returns a string while the default config uses symbols as keys

Fixes #53 