### PR TITLE
Fix error when running `rails generate uploadcare_config` without a config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Gemfile.lock
 .ruby-gemset
 vcs.log
 /spec/cassettes
+/spec/tmp
 *.gem
 /bin
 /vendor

--- a/config/initializers/uploadcare.rb
+++ b/config/initializers/uploadcare.rb
@@ -14,10 +14,10 @@ config =
     eos
 
     {
-      defaults:    { public_key: :demopublickey, private_key: :demoprivatekey },
-      development: { public_key: :demopublickey, private_key: :demoprivatekey },
-      test:        { public_key: :demopublickey, private_key: :demoprivatekey },
-      production:  { public_key: :demopublickey, private_key: :demoprivatekey }
+      defaults:    { public_key: 'demopublickey', private_key: 'demoprivatekey' },
+      development: { public_key: 'demopublickey', private_key: 'demoprivatekey' },
+      test:        { public_key: 'demopublickey', private_key: 'demoprivatekey' },
+      production:  { public_key: 'demopublickey', private_key: 'demoprivatekey' }
     }
   end
 

--- a/lib/uploadcare/rails/settings.rb
+++ b/lib/uploadcare/rails/settings.rb
@@ -31,10 +31,9 @@ module Uploadcare
         :path_value
       ]
 
-
       def initialize(config)
         # extract envaroments settings
-        settings = config[::Rails.env]
+        settings = config.with_indifferent_access[::Rails.env]
         unless settings.present?
           raise ArgumentError, 'config is empty or not given at all'
         end
@@ -44,10 +43,10 @@ module Uploadcare
 
         # strip defaults suplied by uploadcare-ruby gem from private/pub key
         uc_defaults =
-          Uploadcare::DEFAULT_SETTINGS.except!(:public_key, :private_key)
+          Uploadcare::DEFAULT_SETTINGS.except(:public_key, :private_key)
 
-        defaults = Uploadcare::Rails::DEFAULT_SETTINGS.merge!(uc_defaults)
-        settings = defaults.merge!(settings)
+        defaults = Uploadcare::Rails::DEFAULT_SETTINGS.merge(uc_defaults)
+        settings = defaults.merge(settings)
         super settings
 
         # validates settings atributes.

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,28 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140320092807) do
+ActiveRecord::Schema.define(version: 20171012001801) do
 
   create_table "post_with_collections", force: :cascade do |t|
-    t.string   "title"
-    t.string   "file"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.string "title"
+    t.string "file"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "posts", force: :cascade do |t|
-    t.string   "title"
-    t.string   "file"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.string "title"
+    t.string "file"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "posts_with_collection_and_files", force: :cascade do |t|
-    t.string   "title"
-    t.string   "file"
-    t.string   "group"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.string "title"
+    t.string "file"
+    t.string "group"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end

--- a/spec/generators/uploadcare_config_generator_spec.rb
+++ b/spec/generators/uploadcare_config_generator_spec.rb
@@ -1,0 +1,39 @@
+require 'yaml'
+require_relative '../support/generators'
+require 'generators/uploadcare_config_generator'
+
+RSpec.describe UploadcareConfigGenerator, :type => :generator do
+  destination File.expand_path('../tmp', __dir__)
+  let(:config_file_path) { 'spec/tmp/config/uploadcare.yml' }
+  let(:defaults) do
+    {
+      "public_key"=>"demopublickey",
+      "private_key"=>"demoprivatekey",
+      "live"=>true, "cache_files"=>true,
+      "cache_groups"=>true,
+      "store_after_save"=>true,
+      "delete_after_destroy"=>true,
+    }
+  end
+
+  before do
+    prepare_destination
+    expect(File.exists?(config_file_path)).to be(false)
+    run_generator
+  end
+
+  it "generates config/uploadcare.yml" do
+    expect(File.exists?(config_file_path)).to be(true)
+  end
+
+  it "config/uploadcare.yml contains default config" do
+    expect(YAML.load_file(config_file_path)).to eq(
+      "defaults" => defaults,
+      "development" => defaults,
+      "production" => defaults,
+      "test" => defaults,
+    )
+  end
+end
+
+

--- a/spec/support/generators.rb
+++ b/spec/support/generators.rb
@@ -1,0 +1,38 @@
+require 'rails/generators/test_case'
+
+module Uploadcare
+  module Rails
+    module Generators
+      extend ActiveSupport::Concern
+
+      included do
+        cattr_accessor :test_case, :test_case_instance
+
+        self.test_case = Class.new(::Rails::Generators::TestCase) do
+          def fake_test_case; end
+          def add_assertion; end
+        end
+        self.test_case_instance = self.test_case.new(:fake_test_case)
+        self.test_case.generator_class = described_class
+      end
+
+      def prepare_destination
+        self.test_case_instance.send :prepare_destination
+      end
+
+      def run_generator
+        self.test_case_instance.run_generator
+      end
+
+      module ClassMethods
+        def destination(path)
+          self.test_case.destination_root = path
+        end
+      end
+    end
+  end
+end
+
+RSpec.configure do |c|
+  c.include Uploadcare::Rails::Generators, type: :generator
+end

--- a/spec/uploadcare/rails/settings_spec.rb
+++ b/spec/uploadcare/rails/settings_spec.rb
@@ -1,0 +1,136 @@
+require 'spec_helper'
+
+describe Uploadcare::Rails::Settings do
+  subject(:settings) { described_class.new(test: config) }
+
+  let(:full_config) do
+    {
+      widget_version: '2.x',
+      upload_url_base: 'http://example.com/',
+      api_url_base: 'http://example.com/',
+      static_url_base: 'http://example.com/',
+      api_version: '0.3',
+      public_key: 'test_public_key',
+      private_key: 'test_private_key',
+      auth_scheme: :secure,
+      cache_files: true,
+      cache_groups: true,
+      delete_after_destroy: true,
+      store_after_save: true,
+      locale: 'en',
+      images_only: true,
+      multiple: true,
+      multiple_min: 2,
+      multiple_max: 3,
+      preview_step: true,
+      crop: true,
+      clearable: true,
+      tabs: "url file facebook",
+      autostore: true,
+      live: true,
+      manual_start: true,
+      path_value: true,
+    }
+  end
+  let(:config) { full_config }
+
+  it { is_expected.to respond_to(:widget_version) }
+  it { is_expected.to respond_to(:upload_url_base) }
+  it { is_expected.to respond_to(:api_url_base) }
+  it { is_expected.to respond_to(:static_url_base) }
+  it { is_expected.to respond_to(:api_version) }
+  it { is_expected.to respond_to(:cache_files) }
+  it { is_expected.to respond_to(:cache_groups) }
+  it { is_expected.to respond_to(:public_key) }
+  it { is_expected.to respond_to(:private_key) }
+  it { is_expected.to respond_to(:auth_scheme) }
+  it { is_expected.to respond_to(:delete_after_destroy) }
+  it { is_expected.to respond_to(:store_after_save) }
+  it { is_expected.to respond_to(:locale) }
+  it { is_expected.to respond_to(:images_only) }
+  it { is_expected.to respond_to(:multiple) }
+  it { is_expected.to respond_to(:multiple_min) }
+  it { is_expected.to respond_to(:multiple_max) }
+  it { is_expected.to respond_to(:preview_step) }
+  it { is_expected.to respond_to(:crop) }
+  it { is_expected.to respond_to(:clearable) }
+  it { is_expected.to respond_to(:tabs) }
+  it { is_expected.to respond_to(:autostore) }
+  it { is_expected.to respond_to(:live) }
+  it { is_expected.to respond_to(:manual_start) }
+  it { is_expected.to respond_to(:path_value) }
+
+  it { is_expected.to have_attributes(full_config) }
+
+  it { is_expected.to respond_to(:api) }
+  it { expect(settings.api).to be_a(Uploadcare::Api) }
+
+  it { is_expected.to respond_to(:api_settings) }
+  it { expect(settings.api_settings).to eq(settings.to_h) }
+
+  it { is_expected.to respond_to(:widget_settings) }
+  it 'filters private settings' do
+    expect(settings.widget_settings).to eq(
+      public_key: "test_public_key",
+      locale: 'en',
+      images_only: true,
+      multiple: true,
+      multiple_min: 2,
+      multiple_max: 3,
+      preview_step: true,
+      crop: true,
+      clearable: true,
+      tabs: "url file facebook",
+      autostore: true,
+      live: true,
+      manual_start: true,
+      path_value: true,
+    )
+  end
+
+  context 'when no config for the current rails env given' do
+    subject(:settings) { described_class.new(development: config) }
+    it { expect { settings }.to raise_error(ArgumentError) }
+  end
+
+  context 'works with both symbols and strings in a config' do
+    subject(:settings) { described_class.new('test' => config.stringify_keys) }
+    it { is_expected.to have_attributes(full_config) }
+  end
+
+  context 'when some settings are missing in the config' do
+    context 'if missing settings are some of uploadcare-ruby defaults' do
+      let(:uploadcare_ruby_defaults) do
+        Uploadcare::DEFAULT_SETTINGS.except(:public_key, :private_key)
+      end
+      let(:config) { full_config.except(*uploadcare_ruby_defaults.keys) }
+
+      it 'sets missing settings from uploadcare-ruby defaults' do
+        uploadcare_ruby_defaults.each do |k, v|
+          expect(settings).to have_attributes(k => v)
+        end
+      end
+    end
+
+    context 'if public key is missing' do
+      let(:config) { full_config.except(:public_key) }
+      it { expect { settings }.to raise_error(ArgumentError) }
+    end
+
+    context 'if private key is missing' do
+      let(:config) { full_config.except(:private_key) }
+      it { expect { settings }.to raise_error(ArgumentError) }
+    end
+
+    context 'if missing settings are some of uploadcare-rails defaults' do
+      let(:uploadcare_rails_defaults) { Uploadcare::Rails::DEFAULT_SETTINGS }
+      let(:config) { full_config.except(uploadcare_rails_defaults.keys) }
+
+      it 'sets missing settings from uploadcare-rails defaults' do
+        uploadcare_rails_defaults.each do |k, v|
+          expect(settings).to have_attributes(k => v)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- convert config to a hash with indifferent access in Uploadcare::Rails::Settings initializer
- add specs for `Uploadcare::Api::Settings` and config generator

closes #53 