### PR TITLE
Allow scale_crop operations & allow multiple files or multiple groups in the same model

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ production:
   <<: *defaults
 ```
 
-Only two config settings are required: public and private keys. All other posible options are listed [here](https://uploadcare.com/documentation/widget/). Config file created by generator also contains a list of all options with default values. Note that global settings are used for internal API calls and as default config for widget. Any instanse of widget can have separate set of config that will override app-wide settings if needed.
+Only two config settings are required: public and private keys. All other posible options are listed [here](https://uploadcare.com/documentation/widget/). Config file created by generator also contains a list of all options with default values. Note that global settings are used for internal API calls and as default config for widget. Any instance of widget can have separate set of config that will override app-wide settings if needed.
 
 
 # Including widgets and widget configuration
@@ -259,6 +259,7 @@ Operations supported by gem:
 * `progressive: (yes|no)`
 * `preview: (200x150)`
 * `resize: (150x|x200|150x200)`
+* `scale_crop: (150x200|150x200/center)`
 * `inline:` [documentation](https://uploadcare.com/documentation/cdn/#image-operations)
 
 For single file you can pass additional arguments while calling file url:
@@ -266,6 +267,7 @@ For single file you can pass additional arguments while calling file url:
   * ```@post.file.url(preview: '300x300')```
   * ```@post.file.url(quality: :normal)```
   * ```@post.file.url(resize: '150x')```
+  * ```@post.file.url(scale_crop: '150x200')```
 
 Or you can combine existing operation helpers with inline operations from [documentation](https://uploadcare.com/documentation/cdn/#image-operations)
 

--- a/lib/uploadcare/rails/active_record/has_file.rb
+++ b/lib/uploadcare/rails/active_record/has_file.rb
@@ -13,7 +13,7 @@ module Uploadcare
           false
         end
 
-        define_method 'build_file' do
+        define_method "build_file_for_#{attribute}" do
           cdn_url = attributes[attribute.to_s].to_s
           return nil if cdn_url.empty?
 
@@ -32,7 +32,7 @@ module Uploadcare
         # it has some helpers for rails enviroment
         # but it also has all the methods of Uploadcare::File so no worries.
         define_method "#{ attribute }" do
-          build_file
+          self.send("build_file_for_#{attribute}")
         end
 
         define_method "check_#{ attribute }_for_uuid" do
@@ -44,7 +44,7 @@ module Uploadcare
         end
 
         define_method "store_#{ attribute }" do
-          file = build_file
+          file = self.send("build_file_for_#{attribute}")
 
           return unless file
 
@@ -60,7 +60,7 @@ module Uploadcare
         end
 
         define_method "delete_#{ attribute }" do
-          file = build_file
+          file = self.send("build_file_for_#{attribute}")
 
           begin
             file.delete

--- a/lib/uploadcare/rails/active_record/has_group.rb
+++ b/lib/uploadcare/rails/active_record/has_group.rb
@@ -12,7 +12,7 @@ module Uploadcare
           true
         end
 
-        define_method 'build_group' do
+        define_method "build_group_for_#{attribute}" do
           cdn_url = attributes[attribute.to_s].to_s
           return nil if cdn_url.empty?
 
@@ -28,7 +28,7 @@ module Uploadcare
 
         # attribute method - return file object
         define_method "#{ attribute }" do
-          build_group
+          self.send("build_group_for_#{attribute}")
         end
 
         define_method "check_#{ attribute }_for_uuid" do
@@ -44,7 +44,7 @@ module Uploadcare
         end
 
         define_method "store_#{ attribute }" do
-          group = build_group
+          group = self.send("build_group_for_#{attribute}")
           return unless group.present?
 
           begin
@@ -57,7 +57,7 @@ module Uploadcare
         end
 
         define_method "delete_#{ attribute }" do
-          group = build_group
+          group = self.send("build_group_for_#{attribute}")
 
           begin
             group.delete

--- a/lib/uploadcare/rails/objects/file.rb
+++ b/lib/uploadcare/rails/objects/file.rb
@@ -2,7 +2,7 @@ module Uploadcare
   module Rails
     class File < Uploadcare::Api::File
       def url(operations = nil)
-        cdn_url unless operations
+        return cdn_url unless operations
         cdn_url + prepared_operations(operations)
       end
 

--- a/lib/uploadcare/rails/objects/group.rb
+++ b/lib/uploadcare/rails/objects/group.rb
@@ -5,13 +5,15 @@ module Uploadcare
       # warkaround to build images urls without API request
       # builds array of image urls including operations
       def urls(operations = nil)
+        operations = Operations.new(operations).to_s
+
         (0..files_count.to_i - 1).to_a.map do |i|
           [
             @api.options[:static_url_base],
             uuid,
             'nth',
             i,
-            Operations.new(operations).to_s
+            operations
           ].join('/')
         end
       end

--- a/lib/uploadcare/rails/operations.rb
+++ b/lib/uploadcare/rails/operations.rb
@@ -47,6 +47,12 @@ module Uploadcare
         end
       end
 
+      def scale_crop(options)
+        if option = options[/^\d+x\d+(\/center)?$/]
+          "scale_crop/#{ option }"
+        end
+      end
+
       alias_method :size, :resize
 
       def inline(options)

--- a/spec/caching/file_caching_spec.rb
+++ b/spec/caching/file_caching_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Uploadcare::Rails::File, :vcr do
-  let(:post) { Post.new(title: 'Post title', file: FILE_CDN_URL) }
+  let(:post) { Post.new(title: 'Post title', file: FILE_1_CDN_URL) }
 
   context 'when object is not persisted' do
     it 'its file is not loaded' do
@@ -13,7 +13,7 @@ describe Uploadcare::Rails::File, :vcr do
 
   skip 'rails cache should updates after load call' do
     post.file.load!
-    cached = Rails.cache.read FILE_CDN_URL
+    cached = Rails.cache.read FILE_1_CDN_URL
     cached.should be_kind_of(Hash)
     cached['datetime_uploaded'].should be_kind_of(String)
   end

--- a/spec/caching/group_caching_spec.rb
+++ b/spec/caching/group_caching_spec.rb
@@ -1,38 +1,38 @@
 require 'spec_helper'
 
 describe Uploadcare::Rails::Group, :vcr do
-  let(:post)  { PostWithCollection.new(title: 'Title', file: GROUP_CDN_URL) }
+  let(:post)  { PostWithCollection.new(title: 'Title', group: GROUP_1_CDN_URL) }
 
   after :each do
-    Rails.cache.delete(GROUP_CDN_URL)
+    Rails.cache.delete(GROUP_1_CDN_URL)
   end
 
   it 'should be not loaded by default' do
-    expect(post.file).not_to be_loaded
+    expect(post.group).not_to be_loaded
   end
 
   it 'rails cache should be nil' do
-    expect(Rails.cache.read(post.file.cdn_url)).to be_nil
+    expect(Rails.cache.read(post.group.cdn_url)).to be_nil
   end
 
   it 'rails cache should updates after load call' do
-    post.file.load!
-    cached = Rails.cache.read GROUP_CDN_URL
+    post.group.load!
+    cached = Rails.cache.read GROUP_1_CDN_URL
 
     expect(cached).to be_a(Hash)
     expect(cached['datetime_created']).to be_a(String)
   end
 
   it 'group should stay loaded' do
-    expect(post.file).not_to be_loaded
-    post.file.load!
-    expect(post.file).to be_loaded
+    expect(post.group).not_to be_loaded
+    post.group.load!
+    expect(post.group).to be_loaded
   end
 
   it 'cached group should contained json representation of files',
-    vcr: { cassette_name: 'group_cahsing_file_load'} do
-    post.file.load!
-    cached = Rails.cache.read GROUP_CDN_URL
+    vcr: { cassette_name: 'group_caching_file_load'} do
+    post.group.load!
+    cached = Rails.cache.read GROUP_1_CDN_URL
 
     expect(cached).to be_a(Hash)
     expect(cached['files'].sample).to be_a(Hash)

--- a/spec/dummy/app/controllers/post_with_collections_controller.rb
+++ b/spec/dummy/app/controllers/post_with_collections_controller.rb
@@ -53,6 +53,6 @@ class PostWithCollectionsController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def post_with_collection_params
-      params.require(:post_with_collection).permit(:title, :file)
+      params.require(:post_with_collection).permit(:title, :group)
     end
 end

--- a/spec/dummy/app/models/post_with_collection.rb
+++ b/spec/dummy/app/models/post_with_collection.rb
@@ -1,3 +1,3 @@
 class PostWithCollection < ActiveRecord::Base
-  has_uploadcare_group :file
+  has_uploadcare_group :group
 end

--- a/spec/dummy/app/models/post_with_two_collections.rb
+++ b/spec/dummy/app/models/post_with_two_collections.rb
@@ -1,0 +1,4 @@
+class PostWithTwoCollections < ActiveRecord::Base
+  has_uploadcare_group :group_1
+  has_uploadcare_group :group_2
+end

--- a/spec/dummy/app/models/post_with_two_files.rb
+++ b/spec/dummy/app/models/post_with_two_files.rb
@@ -1,0 +1,4 @@
+class PostWithTwoFiles < ActiveRecord::Base
+  has_uploadcare_file :file_1
+  has_uploadcare_file :file_2
+end

--- a/spec/dummy/db/migrate/20171012001801_create_tables.rb
+++ b/spec/dummy/db/migrate/20171012001801_create_tables.rb
@@ -12,7 +12,7 @@ class CreateTables < superclass
 
     create_table :post_with_collections do |t|
       t.string :title
-      t.string :file
+      t.string :group
 
       t.timestamps
     end
@@ -21,6 +21,20 @@ class CreateTables < superclass
       t.string :title
       t.string :file
       t.string :group
+      t.timestamps
+    end
+
+    create_table :post_with_two_collections do |t|
+      t.string :title
+      t.string :group_1
+      t.string :group_2
+      t.timestamps
+    end
+
+    create_table :post_with_two_files do |t|
+      t.string :title
+      t.string :file_1
+      t.string :file_2
       t.timestamps
     end
   end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,28 +10,44 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140320092807) do
+ActiveRecord::Schema.define(version: 20171012001801) do
 
   create_table "post_with_collections", force: :cascade do |t|
-    t.string   "title"
-    t.string   "file"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.string "title"
+    t.string "group"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "post_with_two_collections", force: :cascade do |t|
+    t.string "title"
+    t.string "group_1"
+    t.string "group_2"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "post_with_two_files", force: :cascade do |t|
+    t.string "title"
+    t.string "file_1"
+    t.string "file_2"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "posts", force: :cascade do |t|
-    t.string   "title"
-    t.string   "file"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.string "title"
+    t.string "file"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "posts_with_collection_and_files", force: :cascade do |t|
-    t.string   "title"
-    t.string   "file"
-    t.string   "group"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.string "title"
+    t.string "file"
+    t.string "group"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end

--- a/spec/helpers/form_helpers_has_group_spec.rb
+++ b/spec/helpers/form_helpers_has_group_spec.rb
@@ -8,23 +8,23 @@ describe Uploadcare::Rails::ActionView::FormBuilder, type: :helper do
 
   it "should include uploader tag for name" do
     # not that post has uc file
-    tag = @form.uploadcare_field :file
+    tag = @form.uploadcare_field :group
     expect(tag).to be_kind_of(String)
     expect(tag).to have_selector('input[type="hidden"][data-multiple="true"]', visible: :all)
   end
 
   it "should override uploadcare- attribute" do
-    tag = @form.uploadcare_field :file, :uploadcare => {:multiple => false}
+    tag = @form.uploadcare_field :group, :uploadcare => {:multiple => false}
     expect(tag).to have_selector('input[type="hidden"][data-multiple="true"]', visible: :all)
   end
 
   it "should override data- attribute" do
-    tag = @form.uploadcare_field :file, :data => {:multiple => false}
+    tag = @form.uploadcare_field :group, :data => {:multiple => false}
     expect(tag).to have_selector('input[type="hidden"][data-multiple="true"]', visible: :all)
   end
 
   it "should override data- and uploadcare- attributes" do
-    tag = @form.uploadcare_field :file, :data => {:multiple => false}, :uploadcare => {:multiple => false}
+    tag = @form.uploadcare_field :group, :data => {:multiple => false}, :uploadcare => {:multiple => false}
     expect(tag).to have_selector('input[type="hidden"][data-multiple="true"]', visible: :all)
   end
 end

--- a/spec/models/has_both_file_and_group_spec.rb
+++ b/spec/models/has_both_file_and_group_spec.rb
@@ -4,14 +4,14 @@ describe :has_both_file_and_group_spec do
   let(:subject) do
     PostsWithCollectionAndFile.new(
       title: "Post title",
-      group: GROUP_CDN_URL,
-      file: FILE_CDN_URL
+      group: GROUP_1_CDN_URL,
+      file: FILE_1_CDN_URL
     )
   end
 
   after :each do
-    Rails.cache.delete FILE_CDN_URL
-    Rails.cache.delete GROUP_CDN_URL
+    Rails.cache.delete FILE_1_CDN_URL
+    Rails.cache.delete GROUP_1_CDN_URL
   end
 
   it 'creates empty post' do

--- a/spec/models/has_file_spec.rb
+++ b/spec/models/has_file_spec.rb
@@ -1,9 +1,8 @@
 require 'spec_helper'
 
 describe :has_uploadcare_file, :vcr do
-  let(:post) { Post.new(title: 'Post title', file: FILE_CDN_URL) }
+  let(:post) { Post.new(title: 'Post title', file: FILE_1_CDN_URL) }
   let(:subject) { post }
-  let(:method) { 'file' }
 
   describe 'object with uploadcare_file' do
     it 'creates blank post' do
@@ -34,7 +33,7 @@ describe :has_uploadcare_file, :vcr do
     end
   end
 
-  context 'instanse methods' do
+  context 'instance methods' do
     it '#has_uploadcare_file? returns true' do
       expect(post.has_file_as_uploadcare_file?).to be_truthy
     end

--- a/spec/models/has_group_spec.rb
+++ b/spec/models/has_group_spec.rb
@@ -1,34 +1,34 @@
 require 'spec_helper'
 
 describe :has_uploadcare_group, :vcr do
-  let(:post) { PostWithCollection.new(title: 'Title', file: GROUP_CDN_URL) }
-  let(:method) { 'file' }
+  let(:post) { PostWithCollection.new(title: 'Title', group: GROUP_1_CDN_URL) }
 
   after :each do
-    Rails.cache.delete(GROUP_CDN_URL)
+    Rails.cache.delete(GROUP_1_CDN_URL)
   end
 
   describe 'object with group' do
     let(:subject) { post }
+
     it 'should respond to has_uploadcare_file? method' do
-      is_expected.to respond_to('has_file_as_uploadcare_file?'.to_sym)
+      is_expected.to respond_to('has_group_as_uploadcare_file?'.to_sym)
     end
 
     it 'should respond to has_uploadcare_group? method' do
-      is_expected.to respond_to('has_file_as_uploadcare_group?'.to_sym)
+      is_expected.to respond_to('has_group_as_uploadcare_group?'.to_sym)
     end
 
     it ':has_uploadcare_file? should return true' do
-      is_expected.not_to be_has_file_as_uploadcare_file
+      is_expected.not_to be_has_group_as_uploadcare_file
     end
 
     it ':has_uploadcare_group? should return false' do
-      is_expected.to be_has_file_as_uploadcare_group
+      is_expected.to be_has_group_as_uploadcare_group
     end
   end
 
   describe 'object attachment' do
-    let(:subject) { post.file }
+    let(:subject) { post.group }
 
     it 'should have uploadcare file' do
       is_expected.to be_an(Uploadcare::Rails::Group)
@@ -44,14 +44,16 @@ describe :has_uploadcare_group, :vcr do
 
     it 'stores group after save', vcr: { cassette_name: 'has_uploadcare_group_save' } do
       post.save
+
       is_expected.to be_stored
     end
 
-    skip 'deleteds group after destroy' do
+    skip 'deletes group after destroy' do
       post.save
-      post.file.load
+      post.group.load
       post.destroy
-      expect(post.file).to be_deleted
+
+      expect(post.group).to be_deleted
     end
   end
 end

--- a/spec/models/has_two_files_spec.rb
+++ b/spec/models/has_two_files_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe :has_two_uploadcare_files, :vcr do
+  let(:post) { PostWithTwoFiles.new(title: 'Post title', file_1: FILE_1_CDN_URL, file_2: FILE_2_CDN_URL) }
+  let(:subject) { post }
+
+  describe 'object with uploadcare_files' do
+    it 'creates blank post' do
+      PostWithTwoFiles.create!
+    end
+
+    it 'responds to has_uploadcare_file? method' do
+      is_expected.to respond_to(:has_file_1_as_uploadcare_file?)
+      is_expected.to respond_to(:has_file_2_as_uploadcare_file?)
+    end
+
+    it 'responds to has_uploadcare_group? method' do
+      is_expected.to respond_to(:has_file_1_as_uploadcare_group?)
+      is_expected.to respond_to(:has_file_2_as_uploadcare_group?)
+    end
+
+    it 'has Uploadcare::Rails::File' do
+      expect(post.file_1).to be_an(Uploadcare::Rails::File)
+      expect(post.file_2).to be_an(Uploadcare::Rails::File)
+    end
+
+    it 'stores file after save' do
+      post.save
+
+      expect(post.file_1).to be_stored
+      expect(post.file_2).to be_stored
+    end
+
+    it 'deletes file after destroy', vcr: 'has_upload_care_file_destroy_file' do
+      post.save
+      post.destroy
+
+      expect(post.file_1).to be_deleted
+      expect(post.file_2).to be_deleted
+    end
+  end
+
+  context 'instance methods' do
+    it '#has_uploadcare_file? returns true' do
+      expect(post.has_file_1_as_uploadcare_file?).to be_truthy
+      expect(post.has_file_2_as_uploadcare_file?).to be_truthy
+    end
+
+    it '#has_uploadcare_group? returns false' do
+      expect(post.has_file_1_as_uploadcare_group?).to be_falsey
+      expect(post.has_file_2_as_uploadcare_group?).to be_falsey
+    end
+  end
+end

--- a/spec/models/has_two_groups_spec.rb
+++ b/spec/models/has_two_groups_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe :has_uploadcare_group, :vcr do
+  let(:post) { PostWithTwoCollections.new(title: 'Title', group_1: GROUP_1_CDN_URL, group_2: GROUP_2_CDN_URL) }
+  let(:subject) { post }
+
+  after :each do
+    Rails.cache.delete(GROUP_1_CDN_URL)
+    Rails.cache.delete(GROUP_2_CDN_URL)
+  end
+
+  describe 'object with two groups' do
+    it 'should respond to has_uploadcare_file? method' do
+      is_expected.to respond_to('has_group_1_as_uploadcare_file?'.to_sym)
+      is_expected.to respond_to('has_group_2_as_uploadcare_file?'.to_sym)
+    end
+
+    it 'should respond to has_uploadcare_group? method' do
+      is_expected.to respond_to('has_group_1_as_uploadcare_group?'.to_sym)
+      is_expected.to respond_to('has_group_2_as_uploadcare_group?'.to_sym)
+    end
+
+    it ':has_uploadcare_file? should return true' do
+      is_expected.not_to be_has_group_1_as_uploadcare_file
+      is_expected.not_to be_has_group_2_as_uploadcare_file
+    end
+
+    it ':has_uploadcare_group? should return false' do
+      is_expected.to be_has_group_1_as_uploadcare_group
+      is_expected.to be_has_group_2_as_uploadcare_group
+    end
+  end
+
+  describe 'object attachment' do
+    it 'should have uploadcare file' do
+      expect(post.group_1).to be_an(Uploadcare::Rails::Group)
+      expect(post.group_2).to be_an(Uploadcare::Rails::Group)
+    end
+
+    it 'does not load group by default' do
+      expect(post.group_1).not_to be_loaded
+      expect(post.group_2).not_to be_loaded
+    end
+
+    it 'contains files inside' do
+      expect(post.group_1.load.files.last).to be_an(Uploadcare::Rails::File)
+      expect(post.group_2.load.files.last).to be_an(Uploadcare::Rails::File)
+    end
+
+    it 'stores group after save', vcr: { cassette_name: 'has_uploadcare_group_save' } do
+      post.save
+
+      expect(post.group_1).to be_stored
+      expect(post.group_2).to be_stored
+    end
+
+    skip 'deleteds group after destroy' do
+      post.save
+      post.group_1.load
+      post.group_2.load
+      post.destroy
+
+      expect(post.group_1).to be_deleted
+      expect(post.group_2).to be_deleted
+    end
+  end
+end

--- a/spec/objects/file_spec.rb
+++ b/spec/objects/file_spec.rb
@@ -1,11 +1,11 @@
 require "spec_helper"
 
 describe Uploadcare::Rails::File, :vcr do
-  let(:post) { Post.new(title: "Post title", file: FILE_CDN_URL) }
+  let(:post) { Post.new(title: "Post title", file: FILE_1_CDN_URL) }
   let(:file) { post.file }
 
   after :each do
-    Rails.cache.delete FILE_CDN_URL
+    Rails.cache.delete FILE_1_CDN_URL
   end
 
   it "should be Uploadcare::Rails::File" do

--- a/spec/objects/group_spec.rb
+++ b/spec/objects/group_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
 describe Uploadcare::Rails::Group, :vcr do
-  let(:post) { PostWithCollection.new(title: 'Title', file: GROUP_CDN_URL) }
-  let(:group) { post.file }
+  let(:post) { PostWithCollection.new(title: 'Title', group: GROUP_1_CDN_URL) }
+  let(:group) { post.group }
   let(:subject) { group }
 
   describe 'instance' do
-    it 'is Uploadcare::Rails::Gropu' do
+    it 'is Uploadcare::Rails::Group' do
       is_expected.to be_an(Uploadcare::Rails::Group)
     end
 

--- a/spec/operations_spec.rb
+++ b/spec/operations_spec.rb
@@ -7,6 +7,7 @@ describe Uploadcare::Rails do
       quality: :normal,
       progressive: :yes,
       preview: '200x150',
+      scale_crop: '100x100',
       resize: '150x',
       inline: '//overlay/:uuid/50%x50%/center/'
     }
@@ -18,11 +19,12 @@ describe Uploadcare::Rails do
   it { is_expected.to include('quality/normal') }
   it { is_expected.to include('progressive/yes') }
   it { is_expected.to include('preview/200x150') }
+  it { is_expected.to include('scale_crop/100x100') }
   it { is_expected.to include('resize/150x') }
   it { is_expected.to include('/overlay/:uuid/50%x50%/center/') }
 
   it do
     is_expected.
-      to eq('-/format/jpeg/-/quality/normal/-/progressive/yes/-/preview/200x150/-/resize/150x/-/overlay/:uuid/50%x50%/center/')
+      to eq('-/format/jpeg/-/quality/normal/-/progressive/yes/-/preview/200x150/-/scale_crop/100x100/-/resize/150x/-/overlay/:uuid/50%x50%/center/')
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,19 +14,22 @@ require 'vcr'
 # in spec/support/ and its subdirectories.
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
-@file = File.open(File.join(File.dirname(__FILE__), 'view.png'))
-@uploaded_file = UPLOADCARE_SETTINGS.api.upload(@file)
-@file_cdn_url = @uploaded_file.cdn_url
+@file_1           = File.open(File.join(File.dirname(__FILE__), 'view.png'))
+@uploaded_file_1  = UPLOADCARE_SETTINGS.api.upload(@file_1)
 
-@file = File.open(File.join(File.dirname(__FILE__), 'view.png'))
-@file2 = File.open(File.join(File.dirname(__FILE__), 'view2.jpg'))
-@files_ary = [@file, @file2]
-@files = UPLOADCARE_SETTINGS.api.upload @files_ary
-@uploaded_group = UPLOADCARE_SETTINGS.api.create_group @files
-@group_cdn_url = @uploaded_group.cdn_url
+@file_2           = File.open(File.join(File.dirname(__FILE__), 'view2.jpg'))
+@uploaded_file_2  = UPLOADCARE_SETTINGS.api.upload(@file_2)
 
-GROUP_CDN_URL = @group_cdn_url
-FILE_CDN_URL = @file_cdn_url
+@uploaded_ary_1   = UPLOADCARE_SETTINGS.api.upload [@file_1, @file_2]
+@uploaded_group_1 = UPLOADCARE_SETTINGS.api.create_group @uploaded_ary_1
+
+@uploaded_ary_2   = UPLOADCARE_SETTINGS.api.upload [@file_2, @file_1]
+@uploaded_group_2 = UPLOADCARE_SETTINGS.api.create_group @uploaded_ary_2
+
+FILE_1_CDN_URL    = @uploaded_file_1.cdn_url
+FILE_2_CDN_URL    = @uploaded_file_2.cdn_url
+GROUP_1_CDN_URL   = @uploaded_group_1.cdn_url
+GROUP_2_CDN_URL   = @uploaded_group_2.cdn_url
 
 RSpec.configure do |config|
   # ## Mock Framework

--- a/spec/uploadcare_rails_settings_spec.rb
+++ b/spec/uploadcare_rails_settings_spec.rb
@@ -34,7 +34,7 @@ describe Uploadcare::Rails do
   end
 
   # TODO: test api settings and widget settings
-  it "should build instanse of UC api" do
+  it "should build instance of UC api" do
     UPLOADCARE_SETTINGS.api.should be_kind_of(Uploadcare::Api)
   end
 


### PR DESCRIPTION
When I tried to use uploadcare-rails on a model with multiple groups, or multiple files, weird things happened and the integration didn't work. After some spelunking, I realized it was because, although all other dynamic methods were dynamically named based on attribute name, #build_file and #build_group were not. Therefore, you'd get bleedover between the two attributes.

I also discovered that some presumably newer operations - in my case scale_crop - weren't supported.

This pull request remedies both of those situations.

If this work is useful, please consider accepting this into the main repository. I'm sure it would be helpful to others. I've included full unit tests for all of my changes.

While I was at it, I couldn't resist renaming the attributes in the specs so that group attributes were called ```group``` or ```group_1``` instead of ```file```.