### PR TITLE
Add secure webhooks option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based now on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 2.0.1 2021-11-16
+## 2.1.0 2021-11-16
+### Added
 
-- Add option "signing_secret" to Webhooks API
-
+- Option `signing_secret` in the `Uploadcare::WebhookApi`.
 
 ## 2.0.0 - 2021-10-11
 ### :heavy_exclamation_mark: *Note: the gem uploadcare-rails 2.x is not backward compatible with 1.x.*
@@ -96,7 +96,3 @@ Configuration object is available as `Uploadcare::Rails.configuration` now
 ### Devepopment
 - Tests have been refactored, VCR appended to development environment.
 - Tests perfomance improvements.
-
-
-[Unreleased]: https://github.com/uploadcare/uploadcare-rails/compare/v1.2.0...HEAD
-[1.2.0]: https://github.com/uploadcare/uploadcare-rails/compare/v1.2.0...v1.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,13 +86,13 @@ Configuration object is available as `Uploadcare::Rails.configuration` now
 
 ## 1.1.0 - 2016-07-12
 ### Added
-- Removed widget from the asset pipeline. It is expected to use helper or to append to the asset pipeline mannualy.
+- Removed widget from the asset pipeline. It is expected to use helper or to append to the asset pipeline manually.
 - Operations for image_tag helpers.
 
 ### Fixed
 - Bug with creating object with empty file or file_group.
-- Workaround to remove unnecessery API cals for groups of images.
+- Workaround to remove unnecessary API-calls for groups of images.
 
-### Devepopment
+### Development
 - Tests have been refactored, VCR appended to development environment.
-- Tests perfomance improvements.
+- Tests performance improvements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based now on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 2.0.1 2021-11-16
+
+- Add option "signing_secret" to Webhooks API
+
+
 ## 2.0.0 - 2021-10-11
 ### :heavy_exclamation_mark: *Note: the gem uploadcare-rails 2.x is not backward compatible with 1.x.*
-
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -703,11 +703,14 @@ $ Uploadcare::WebhookApi.get_webhooks
 
 This method requires an URL that is triggered by an event, for example, a file upload. A target URL MUST be unique for each project — event type combination.
 
+Each webhook payload can be signed with a secret (the `signing_secret` option) to ensure that the request comes from the expected sender.
+More info about secure webhooks [here](https://uploadcare.com/docs/security/secure-webhooks/).
+
 ```console
 # Valid options:
 # event: ["file.uploaded"]
 # is_active: [true|false]
-$ Uploadcare::WebhookApi.create_webhook("https://example.com", event: "file.uploaded", is_active: true)
+$ Uploadcare::WebhookApi.create_webhook("https://example.com", event: "file.uploaded", is_active: true, signing_secret: "some-secret")
 #   => {
 #        "id"=>815671,
 #        "created"=>"2021-08-02T05:02:14.588794Z",
@@ -722,13 +725,13 @@ $ Uploadcare::WebhookApi.create_webhook("https://example.com", event: "file.uplo
 
 #### Update an existing webhook by ID
 
-Updating a webhook is available if webhook ID is known. The ID is returned in a response on creating or listing webhooks.
+Updating a webhook is available if webhook ID is known. The ID is returned in a response on creating or listing webhooks. Setting a signing secret is supported when updating a webhook as well.
 
 ```console
 # Valid options:
 # event: Presently, we only support the "file.uploaded" event
 # is_active: [true|false]
-$ Uploadcare::WebhookApi.update_webhook("webhook_id", target_url: "https://example1.com", event: "file.uploaded", is_active: false)
+$ Uploadcare::WebhookApi.update_webhook("webhook_id", target_url: "https://example1.com", event: "file.uploaded", is_active: false, signing_secret: "some-secret")
 #   => {
 #        "id"=>815671,
 #        "created"=>"2021-08-02T05:02:14.588794Z",

--- a/lib/uploadcare/rails/api/rest/webhook_api.rb
+++ b/lib/uploadcare/rails/api/rest/webhook_api.rb
@@ -19,9 +19,9 @@ module Uploadcare
 
             # Create a webhook
             # @see https://uploadcare.com/api-refs/rest-api/v0.5.0/#operation/webhookCreate
-            def create_webhook(target_url, event: 'file.uploaded', is_active: true)
-              options = { target_url: target_url, event: event, is_active: is_active }
-              Uploadcare::Webhook.create(**options)
+            def create_webhook(target_url, event: 'file.uploaded', is_active: true, signing_secret: nil)
+              options = { target_url: target_url, event: event, is_active: is_active, signing_secret: signing_secret }
+              Uploadcare::Webhook.create(**options.compact)
             end
 
             # Updates a webhook

--- a/lib/uploadcare/rails/version.rb
+++ b/lib/uploadcare/rails/version.rb
@@ -2,6 +2,6 @@
 
 module Uploadcare
   module Rails
-    VERSION = '2.0.0'
+    VERSION = '2.1.0'
   end
 end

--- a/spec/uploadcare/rails/api/rest/webhook_api_spec.rb
+++ b/spec/uploadcare/rails/api/rest/webhook_api_spec.rb
@@ -28,7 +28,10 @@ module Uploadcare
 
             it 'creates a webhook', :aggregate_failures do
               VCR.use_cassette('webhook_api_create_webhook') do
-                response = subject.create_webhook('https://ucarecdn.com/3542c513-5cf4-4adb-97b0-bfa7fbd31fb5/11.png')
+                response = subject.create_webhook(
+                  'https://ucarecdn.com/3542c513-5cf4-4adb-97b0-bfa7fbd31fb5/11.png',
+                  signing_secret: '1234'
+                )
                 %w[id created updated event target_url project is_active].each do |key|
                   expect(response).to have_key(key)
                 end
@@ -38,7 +41,12 @@ module Uploadcare
             it 'updates a webhook', :aggregate_failures do
               VCR.use_cassette('webhook_api_update_webhook') do
                 new_target_url = 'https://ucarecdn.com/3542c513-5cf4-4adb-97b0-bfa7fbd31fb5/11.png'
-                response = subject.update_webhook('811134', target_url: new_target_url, is_active: false)
+                response = subject.update_webhook(
+                  '811134',
+                  target_url: new_target_url,
+                  is_active: false,
+                  signing_secret: '1234'
+                )
                 expect(response['target_url']).to eq(new_target_url)
                 expect(response['is_active']).to eq(false)
               end


### PR DESCRIPTION
## Description

- Add the `signing secret` option to Webhooks API #create and #update methods 


## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
