### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ You must set the gem before `uploadcare-rails` like this :
 gem "dotenv-rails", require: "dotenv/rails-now", groups: [:development, :test]
 gem "uploadcare-rails"
 ```
+`require: "dotenv/rails-now"` is very important
 
 Run the config generator command to generate a configuration file:
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ You must set the gem before `uploadcare-rails` like this :
 gem "dotenv-rails", require: "dotenv/rails-now", groups: [:development, :test]
 gem "uploadcare-rails"
 ```
-`require: "dotenv/rails-now"` is very important
+:warning: `require: "dotenv/rails-now"` is very important !
 
 Run the config generator command to generate a configuration file:
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ You must set the gem before `uploadcare-rails` like this :
 gem "dotenv-rails", require: "dotenv/rails-now", groups: [:development, :test]
 gem "uploadcare-rails"
 ```
-:warning: `require: "dotenv/rails-now"` is very important !
+:warning: `require: "dotenv/rails-now"` is very important!
 
 Run the config generator command to generate a configuration file:
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ $ export UPLOADCARE_PUBLIC_KEY=demopublickey
 $ export UPLOADCARE_SECRET_KEY=demoprivatekey
 ```
 Or you can use popular gems like `dotenv-rails` for setting ENV variables.
+You must set the gem before `uploadcare-rails` like this :
+```ruby
+gem "dotenv-rails", require: "dotenv/rails-now", groups: [:development, :test]
+gem "uploadcare-rails"
+```
 
 Run the config generator command to generate a configuration file:
 


### PR DESCRIPTION
## Description

Based on the issue https://github.com/uploadcare/uploadcare-rails/issues/105, I wrote some information that can help someone else.
It says that we need to specify `gem "dotenv-rails", require: "dotenv/rails-now"` and not `gem "dotenv-rails"` to be able to use `uploadcare-rails`