### PR TITLE
Add Ruby 3.1 and 3.2 to CI.  Update checkout action version.

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Release Gem
         if: contains(github.ref, 'refs/tags/v')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,9 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
-          - 3.0
+          - '3.0'
+          - 3.1
+          - 3.2
         exclude:
           - ruby: 2.4
             gemfile: Gemfile
@@ -49,23 +51,47 @@ jobs:
             gemfile: gemfiles/Gemfile-rails-5-1
           - ruby: 2.7
             gemfile: gemfiles/Gemfile-rails-5-2
-          - ruby: 3.0
+          - ruby: '3.0'
             gemfile: gemfiles/Gemfile-rails-4-1
-          - ruby: 3.0
+          - ruby: '3.0'
             gemfile: gemfiles/Gemfile-rails-4-2
-          - ruby: 3.0
+          - ruby: '3.0'
             gemfile: gemfiles/Gemfile-rails-5-0
-          - ruby: 3.0
+          - ruby: '3.0'
             gemfile: gemfiles/Gemfile-rails-5-1
-          - ruby: 3.0
+          - ruby: '3.0'
             gemfile: gemfiles/Gemfile-rails-5-2
+          - ruby: 3.1
+            gemfile: gemfiles/Gemfile-rails-4-1
+          - ruby: 3.1
+            gemfile: gemfiles/Gemfile-rails-4-2
+          - ruby: 3.1
+            gemfile: gemfiles/Gemfile-rails-5-0
+          - ruby: 3.1
+            gemfile: gemfiles/Gemfile-rails-5-1
+          - ruby: 3.1
+            gemfile: gemfiles/Gemfile-rails-5-2
+          - ruby: 3.1
+            gemfile: gemfiles/Gemfile-rails-6-0
+          - ruby: 3.2
+            gemfile: gemfiles/Gemfile-rails-4-1
+          - ruby: 3.2
+            gemfile: gemfiles/Gemfile-rails-4-2
+          - ruby: 3.2
+            gemfile: gemfiles/Gemfile-rails-5-0
+          - ruby: 3.2
+            gemfile: gemfiles/Gemfile-rails-5-1
+          - ruby: 3.2
+            gemfile: gemfiles/Gemfile-rails-5-2
+          - ruby: 3.2
+            gemfile: gemfiles/Gemfile-rails-6-0
     runs-on: ubuntu-latest
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
       UPLOADCARE_PUBLIC_KEY: demopublickey
       UPLOADCARE_SECRET_KEY: demoprivatekey
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Bundler 1.x for Rails 4.x
         if: ${{ matrix.ruby == '2.4' || matrix.ruby == '2.5' }}
         run: echo "BUNDLER_VERSION=1.17.3" >> $GITHUB_ENV
@@ -82,7 +108,7 @@ jobs:
       matrix:
         ruby-version: ['2.7',]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
## Description

Adds Ruby 3.1 and 3.2 to CI
Updates the checkout action version to v3 to eliminate Node warnings
Quoted the "3.0" to ensure that it loads Ruby 3.0 and not Ruby 3.2 for those entries (an unquoted 3.0 is truncated to 3)
