### PR TITLE
Fix that we were trying use regex to match ID as single digit and this did not work for more than 10 files in id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based now on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 3.4.1 — 2024-03-24
+
+### Fixed
+
+* Fixed invalid group id error when >= 10 files are uploaded when using `mount_uploadcare_file_group`.
+
 ## 3.4.0 — 2024-03-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ The helper is detecting the value of the `multiple` property based on the mount 
 ### File and Group wrappers
 
 When you mount either Uploadcare File or Group to an attribute, this attribute is getting wrapped with
-a Uploadcare object. This feature adds some usefull methods to the attribute.
+a Uploadcare object. This feature adds some useful methods to the attribute.
 
 #### Uploadcare File
 
@@ -300,7 +300,7 @@ class Post < ApplicationRecord
 end
 ```
 
-And then you create a new Post object specifying a CDN-url for your prevously uploaded Uploadcare file:
+And then you create a new Post object specifying a CDN-url for your previously uploaded Uploadcare file:
 
 ```console
 $ post = Post.create(picture: "https://ucarecdn.com/2d33999d-c74a-4ff9-99ea-abc23496b052/")

--- a/lib/uploadcare/rails/active_record/mount_uploadcare_file_group.rb
+++ b/lib/uploadcare/rails/active_record/mount_uploadcare_file_group.rb
@@ -13,7 +13,7 @@ module Uploadcare
       module MountUploadcareFileGroup
         extend ActiveSupport::Concern
 
-        GROUP_ID_REGEX = /\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b~\d/.freeze
+        GROUP_ID_REGEX = /\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b~\d+/.freeze
 
         def build_uploadcare_file_group(attribute)
           cdn_url = attributes[attribute.to_s].to_s

--- a/lib/uploadcare/rails/version.rb
+++ b/lib/uploadcare/rails/version.rb
@@ -2,6 +2,6 @@
 
 module Uploadcare
   module Rails
-    VERSION = '3.4.0'
+    VERSION = '3.4.1'
   end
 end

--- a/spec/uploadcare/rails/active_record/mount_uploadcare_group_spec.rb
+++ b/spec/uploadcare/rails/active_record/mount_uploadcare_group_spec.rb
@@ -30,13 +30,17 @@ describe Uploadcare::Rails::ActiveRecord::MountUploadcareFileGroup do
     end
   end
 
-  describe "GROUP_ID_REGEX" do
+  describe 'GROUP_ID_REGEX' do
     it 'properly extracts out group id from the cdn url' do
-      extracted_group_id = Uploadcare::Rails::IdExtractor.call('https://ucarecdn.com/dc140069-62b1-4ee0-b603-18e2062e26e4~11/', subject::GROUP_ID_REGEX)
-      expect(extracted_group_id).to eq("dc140069-62b1-4ee0-b603-18e2062e26e4~11")
+      extracted_group_id = Uploadcare::Rails::IdExtractor.call(
+        'https://ucarecdn.com/dc140069-62b1-4ee0-b603-18e2062e26e4~11/', subject::GROUP_ID_REGEX
+      )
+      expect(extracted_group_id).to eq('dc140069-62b1-4ee0-b603-18e2062e26e4~11')
 
-      extracted_group_id = Uploadcare::Rails::IdExtractor.call('https://ucarecdn.com/dc140069-62b1-4ee0-b603-18e2062e26e4~1/', subject::GROUP_ID_REGEX)
-      expect(extracted_group_id).to eq("dc140069-62b1-4ee0-b603-18e2062e26e4~1")
+      extracted_group_id = Uploadcare::Rails::IdExtractor.call(
+        'https://ucarecdn.com/dc140069-62b1-4ee0-b603-18e2062e26e4~1/', subject::GROUP_ID_REGEX
+      )
+      expect(extracted_group_id).to eq('dc140069-62b1-4ee0-b603-18e2062e26e4~1')
     end
   end
 end

--- a/spec/uploadcare/rails/active_record/mount_uploadcare_group_spec.rb
+++ b/spec/uploadcare/rails/active_record/mount_uploadcare_group_spec.rb
@@ -29,4 +29,14 @@ describe Uploadcare::Rails::ActiveRecord::MountUploadcareFileGroup do
       expect(Post).to respond_to(:has_uploadcare_file_group_for_gallery?)
     end
   end
+
+  describe "GROUP_ID_REGEX" do
+    it 'properly extracts out group id from the cdn url' do
+      extracted_group_id = Uploadcare::Rails::IdExtractor.call('https://ucarecdn.com/dc140069-62b1-4ee0-b603-18e2062e26e4~11/', subject::GROUP_ID_REGEX)
+      expect(extracted_group_id).to eq("dc140069-62b1-4ee0-b603-18e2062e26e4~11")
+
+      extracted_group_id = Uploadcare::Rails::IdExtractor.call('https://ucarecdn.com/dc140069-62b1-4ee0-b603-18e2062e26e4~1/', subject::GROUP_ID_REGEX)
+      expect(extracted_group_id).to eq("dc140069-62b1-4ee0-b603-18e2062e26e4~1")
+    end
+  end
 end


### PR DESCRIPTION
## Description

- [#133] Fix that we were trying use regex to match ID as single digit and this did not work for more than 10 files in id
- This resulted in wrong group id, which made grouping not usable at all for groups with files count >= 10
- Also some README fixes

Closes #133 

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
