### PR TITLE
Openstruct has been removed from rails specs. Lets require ourselves.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require 'dry/monads/all'
 require 'api_struct'
 require 'uploadcare'
 require 'action_view'
+require 'ostruct'
 
 Dir[File.expand_path(File.join(File.dirname(__FILE__), 'support', '**', '*.rb'))].sort.each { |f| require f }
 


### PR DESCRIPTION
## Description

Ref: https://github.com/rails/rails/pull/51510/files

## Checklist

- [x] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved code structure by including enhanced support for mock objects in tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->