### PR TITLE
Add AWS Rekognition moderation Add-On methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based now on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+* Added Addons api for `AWS Rekognition Moderation` Add-On.
+
 ## 3.4.1 — 2024-03-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ post.picture.store
 #          ...other group data...
 #      }
 
+#
 # Delete the file from an Uploadcare server permanently:
 post.picture.delete
 #   => {
@@ -422,6 +423,7 @@ post.attachments.store
 #         }]
 #      }
 
+#
 # Delete the file group from an Uploadcare server permanently:
 post.attachments.delete
 #   => {
@@ -976,6 +978,25 @@ Uploadcare::AddonsApi.rekognition_detect_labels('f757ea10-8b1a-4361-9a7c-56bfa5d
 Uploadcare::AddonsApi.rekognition_detect_labels_status('dfeaf81c-5c0d-49d5-8ed4-ac09bac7998e')
 #   => {"status"=>"done"}
 ```
+
+#### Execute AWS Rekognition Moderation Add-On for a given target to detect moderation labels in an image.
+```
+  Note: Detected labels are stored in the file's appdata.
+```
+
+```ruby
+Uploadcare::AddonsApi.rekognition_detect_moderation_labels('f757ea10-8b1a-4361-9a7c-56bfa5d45176')
+#   => {"request_id"=>"dfeaf81c-5c0d-49d5-8ed4-ac09bac7998e"}
+```
+
+# Check the status of an AWS Rekognition Moderation Add-On execution request that had been started using the Execute Add-On operation.
+
+```ruby
+Uploadcare::AddonsApi.rekognition_detect_moderation_labels_status('dfeaf81c-5c0d-49d5-8ed4-ac09bac7998e')
+#   => {"status"=>"done"}
+```
+
+
 
 #### Execute ClamAV virus checking Add-On for a given target
 

--- a/lib/uploadcare/rails/api/rest/addons_api.rb
+++ b/lib/uploadcare/rails/api/rest/addons_api.rb
@@ -44,6 +44,18 @@ module Uploadcare
             def remove_bg_status(uuid)
               Uploadcare::Addons.remove_bg_status(uuid)
             end
+
+            # Execute AWS Rekognition Moderation Add-On for a given target to detect labels in an image.
+            # @see https://uploadcare.com/api-refs/rest-api/v0.7.0/#tag/Add-Ons/operation/awsRekognitionDetectModerationLabelsExecute
+            def rekognition_detect_moderation_labels(uuid)
+              Uploadcare::Addons.ws_rekognition_detect_moderation_labels(uuid)
+            end
+
+            # Check the status of an Add-On execution request that had been started using the Execute Add-On operation.
+            # @see https://uploadcare.com/api-refs/rest-api/v0.7.0/#tag/Add-Ons/operation/awsRekognitionDetectModerationLabelsExecutionStatus
+            def rekognition_detect_moderation_labels_status(uuid)
+              Uploadcare::Addons.ws_rekognition_detect_moderation_labels_status(uuid)
+            end
           end
         end
       end

--- a/spec/fixtures/vcr_cassettes/group_api_get_group.yml
+++ b/spec/fixtures/vcr_cassettes/group_api_get_group.yml
@@ -2,13 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://upload.uploadcare.com/group/info/?group_id=6053b054-b8d4-4f57-992d-94b8f1d6ba65~2&pub_key=demopublickey
+    uri: https://upload.uploadcare.com/group/info/?group_id=6053b054-b8d4-4f57-992d-94b8f1d6ba65~2&pub_key=<uploadcare_private_key>
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: ''
     headers:
       User-Agent:
-      - UploadcareRuby/4.0.0/5d5bb5639e3f2df33674 (Ruby/3.0.0)
+      - UploadcareRuby/4.4.1/<uploadcare_private_key> (Ruby/3.3.0)
       Connection:
       - close
       Host:
@@ -19,11 +19,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sun, 30 Oct 2022 20:30:29 GMT
+      - Fri, 03 May 2024 09:55:02 GMT
       Content-Type:
-      - application/json
+      - text/plain; charset=utf-8
       Content-Length:
-      - '1732'
+      - '20'
       Connection:
       - close
       Server:
@@ -36,7 +36,7 @@ http_interactions:
       Access-Control-Allow-Methods:
       - GET, HEAD, OPTIONS
       Access-Control-Allow-Headers:
-      - X-UC-User-Agent, X-PINGOTHER, DNT
+      - DNT, X-UC-User-Agent, X-PINGOTHER
       Access-Control-Max-Age:
       - '1'
       Access-Control-Allow-Credentials:
@@ -52,5 +52,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"id":"6053b054-b8d4-4f57-992d-94b8f1d6ba65~2","datetime_created":"2022-10-29T16:53:33.220316Z","datetime_stored":null,"files_count":2,"cdn_url":"https://ucarecdn.com/6053b054-b8d4-4f57-992d-94b8f1d6ba65~2/","url":"https://api.uploadcare.com/groups/6053b054-b8d4-4f57-992d-94b8f1d6ba65~2/","files":[{"size":2766,"total":2766,"done":2766,"uuid":"272cbffa-4a27-4aba-98f1-a36e2e017e24","file_id":"272cbffa-4a27-4aba-98f1-a36e2e017e24","original_filename":"image.png","is_image":true,"is_stored":true,"image_info":{"dpi":null,"width":50,"format":"PNG","height":42,"sequence":false,"color_mode":"RGBA","orientation":null,"geo_location":null,"datetime_original":null},"video_info":null,"content_info":{"mime":{"mime":"image/png","type":"image","subtype":"png"},"image":{"dpi":null,"width":50,"format":"PNG","height":42,"sequence":false,"color_mode":"RGBA","orientation":null,"geo_location":null,"datetime_original":null}},"is_ready":true,"filename":"image.png","mime_type":"image/png","metadata":{},"default_effects":""},{"size":2950,"total":2950,"done":2950,"uuid":"36892dd8-ccb1-4225-bc48-96a0fde93b33","file_id":"36892dd8-ccb1-4225-bc48-96a0fde93b33","original_filename":"image.png","is_image":true,"is_stored":true,"image_info":{"dpi":null,"width":50,"format":"PNG","height":42,"sequence":false,"color_mode":"RGBA","orientation":null,"geo_location":null,"datetime_original":null},"video_info":null,"content_info":{"mime":{"mime":"image/png","type":"image","subtype":"png"},"image":{"dpi":null,"width":50,"format":"PNG","height":42,"sequence":false,"color_mode":"RGBA","orientation":null,"geo_location":null,"datetime_original":null}},"is_ready":true,"filename":"image.png","mime_type":"image/png","metadata":{},"default_effects":""}]}'
-  recorded_at: Sun, 30 Oct 2022 20:30:29 GMT
-recorded_with: VCR 6.1.0
+  recorded_at: Fri, 03 May 2024 09:55:02 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/remove_bg.yml
+++ b/spec/fixtures/vcr_cassettes/remove_bg.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.uploadcare.com/addons/remove_bg/execute/
+    body:
+      encoding: UTF-8
+      string: '{"target":"ff4d3d37-4de0-4f6d-a7db-8cdabe7fc768","params":{"crop":true,"type_level":"2"}}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/vnd.uploadcare-v0.7+json
+      User-Agent:
+      - UploadcareRuby/4.4.1/demopublickey (Ruby/3.1.3)
+      Date:
+      - Mon, 29 Apr 2024 08:24:06 GMT
+      Authorization:
+      - Uploadcare demopublickey:90c523b1b76b9befe65b0348b7ec5136778c27c7
+      Connection:
+      - close
+      Host:
+      - api.uploadcare.com
+  response:
+    status:
+      code: 200
+      message: ok
+    headers:
+      Date:
+      - Mon, 29 Apr 2024 08:24:07 GMT
+      Content-Type:
+      - application/vnd.uploadcare-v0.7+json
+      Content-Length:
+      - '61'
+      Connection:
+      - close
+      Server:
+      - nginx
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Vary:
+      - Accept
+      Allow:
+      - OPTIONS, POST
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Uploadcare-Request-Id:
+      - fa835f97-bf32-4abd-a351-02e4875587af
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: '{"request_id": "c3446e41-9eb0-4301-aeb4-356d0fdcf9af"}'
+  recorded_at: Mon, 29 Apr 2024 08:24:07 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/remove_bg_status.yml
+++ b/spec/fixtures/vcr_cassettes/remove_bg_status.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.uploadcare.com/addons/remove_bg/execute/status/?request_id=c3446e41-9eb0-4301-aeb4-356d0fdcf9af
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/vnd.uploadcare-v0.7+json
+      User-Agent:
+      - UploadcareRuby/4.4.1/demopublickey (Ruby/3.1.3)
+      Date:
+      - Mon, 29 Apr 2024 08:30:02 GMT
+      Authorization:
+      - Uploadcare demopublickey:94ac47fc49b77fe98e78da427888209ebcfdd3c8
+      Connection:
+      - close
+      Host:
+      - api.uploadcare.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Apr 2024 08:30:03 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '21'
+      Connection:
+      - close
+      Server:
+      - nginx
+      Vary:
+      - Accept
+      - Accept-Encoding
+      Warning:
+      - '199 Miscellaneous warning: You are using the demo project'
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Uploadcare-Request-Id:
+      - 147020f2-a091-4b2b-9861-8fda3eb5e9e6
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: '{"status": "done", "result": {"file_id": "bc37b996-916d-4ed7-b230-fa71a4290cb3"}}'
+  recorded_at: Mon, 29 Apr 2024 08:30:03 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/uc_clamav_virus_scan.yml
+++ b/spec/fixtures/vcr_cassettes/uc_clamav_virus_scan.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.uploadcare.com/addons/uc_clamav_virus_scan/execute/
+    body:
+      encoding: UTF-8
+      string: '{"target":"ff4d3d37-4de0-4f6d-a7db-8cdabe7fc768","params":{"purge_infected":true}}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/vnd.uploadcare-v0.7+json
+      User-Agent:
+      - UploadcareRuby/4.4.1/demopublickey (Ruby/3.1.3)
+      Date:
+      - Mon, 29 Apr 2024 07:34:46 GMT
+      Authorization:
+      - Uploadcare demopublickey:29d71f9f2eda92585cca7e4bd363947c1e2f6181
+      Connection:
+      - close
+      Host:
+      - api.uploadcare.com
+  response:
+    status:
+      code: 200
+      message: ok
+    headers:
+      Date:
+      - Mon, 29 Apr 2024 07:34:47 GMT
+      Content-Type:
+      - application/vnd.uploadcare-v0.7+json
+      Content-Length:
+      - '23'
+      Connection:
+      - close
+      Server:
+      - nginx
+      Warning:
+      - '199 Miscellaneous warning: You are using the demo project'
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Vary:
+      - Accept
+      Allow:
+      - OPTIONS, POST
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Uploadcare-Request-Id:
+      - 19d6a042-2380-44af-8c0a-9249394a8ba3
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: '{"request_id": "34abf037-5384-4e38-bad4-97dd48e79acd"}'
+  recorded_at: Mon, 29 Apr 2024 07:34:47 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/uc_clamav_virus_scan_status.yml
+++ b/spec/fixtures/vcr_cassettes/uc_clamav_virus_scan_status.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.uploadcare.com/addons/uc_clamav_virus_scan/execute/status/?request_id=34abf037-5384-4e38-bad4-97dd48e79acd
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/vnd.uploadcare-v0.7+json
+      User-Agent:
+      - UploadcareRuby/4.4.1/demopublickey (Ruby/3.1.3)
+      Date:
+      - Mon, 29 Apr 2024 08:11:09 GMT
+      Authorization:
+      - Uploadcare demopublickey:b34e648a65c8bc183bfb0e44b9a3809553329a08
+      Connection:
+      - close
+      Host:
+      - api.uploadcare.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Apr 2024 08:11:10 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '21'
+      Connection:
+      - close
+      Server:
+      - nginx
+      Vary:
+      - Accept
+      - Accept-Encoding
+      Warning:
+      - '199 Miscellaneous warning: You are using the demo project'
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Uploadcare-Request-Id:
+      - b51a4ada-e222-489f-8193-481a6f7d0541
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: '{"status": "done"}'
+  recorded_at: Mon, 29 Apr 2024 08:11:10 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/ws_rekognition_detect_labels.yml
+++ b/spec/fixtures/vcr_cassettes/ws_rekognition_detect_labels.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.uploadcare.com/addons/aws_rekognition_detect_labels/execute/
+    body:
+      encoding: UTF-8
+      string: '{"target":"ff4d3d37-4de0-4f6d-a7db-8cdabe7fc768"}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/vnd.uploadcare-v0.7+json
+      User-Agent:
+      - UploadcareRuby/3.3.2/5d5bb5639e3f2df33674 (Ruby/2.6.0)
+      Date:
+      - Fri, 23 Sep 2022 11:26:10 GMT
+      Authorization:
+      - Uploadcare 5d5bb5639e3f2df33674:33112e124819aed499753dd8035394536a15e55c
+      Connection:
+      - close
+      Host:
+      - api.uploadcare.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 23 Sep 2022 11:26:10 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '54'
+      Connection:
+      - close
+      Server:
+      - nginx
+      Vary:
+      - Accept
+      - Accept-Encoding
+      Warning:
+      - '199 Miscellaneous warning: Please use API version 0.5, not 0.7'
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - OPTIONS, POST
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Uploadcare-Request-Id:
+      - 0f4598dd-d168-4272-b49e-e7f9d2543542
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: '{"request_id": "0f4598dd-d168-4272-b49e-e7f9d2543542"}'
+  recorded_at: Mon, 29 Apr 2024 08:11:10 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/ws_rekognition_detect_labels_status.yml
+++ b/spec/fixtures/vcr_cassettes/ws_rekognition_detect_labels_status.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.uploadcare.com/addons/aws_rekognition_detect_labels/execute/status/?request_id=0f4598dd-d168-4272-b49e-e7f9d2543542
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/vnd.uploadcare-v0.7+json
+      User-Agent:
+      - UploadcareRuby/3.3.2/5d5bb5639e3f2df33674 (Ruby/2.6.0)
+      Date:
+      - Fri, 23 Sep 2022 11:28:43 GMT
+      Authorization:
+      - Uploadcare 5d5bb5639e3f2df33674:2b5bce3caafb3c58798eb57b487fe64f882f97b1
+      Connection:
+      - close
+      Host:
+      - api.uploadcare.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 23 Sep 2022 11:28:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '18'
+      Connection:
+      - close
+      Server:
+      - nginx
+      Warning:
+      - '199 Miscellaneous warning: Please use API version 0.5, not 0.7'
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Vary:
+      - Accept
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Uploadcare-Request-Id:
+      - 7625f6b7-8688-42aa-87c1-437a80bac0ad
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: '{"status": "done"}'
+  recorded_at: Mon, 29 Apr 2024 08:20:10 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/ws_rekognition_detect_moderation_labels.yml
+++ b/spec/fixtures/vcr_cassettes/ws_rekognition_detect_moderation_labels.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.uploadcare.com/addons/aws_rekognition_detect_moderation_labels/execute/
+    body:
+      encoding: UTF-8
+      string: '{"target":"ff4d3d37-4de0-4f6d-a7db-8cdabe7fc768"}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/vnd.uploadcare-v0.7+json
+      User-Agent:
+      - UploadcareRuby/4.4.1/demopublickey (Ruby/3.1.3)
+      Date:
+      - Mon, 29 Apr 2024 08:36:32 GMT
+      Authorization:
+      - Uploadcare demopublickey:d846dea78a370b87b0a3938fcfcc4c6f09cd84bc
+      Connection:
+      - close
+      Host:
+      - api.uploadcare.com
+  response:
+    status:
+      code: 200
+      message: ok
+    headers:
+      Date:
+      - Mon, 29 Apr 2024 08:36:33 GMT
+      Content-Type:
+      - application/vnd.uploadcare-v0.7+json
+      Content-Length:
+      - '61'
+      Connection:
+      - close
+      Server:
+      - nginx
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Vary:
+      - Accept
+      Allow:
+      - OPTIONS, POST
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Uploadcare-Request-Id:
+      - d503b38b-4b97-4c54-918d-9df511985cfa
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: '{"request_id": "0f4598dd-d168-4272-b49e-e7f9d2543542"}'
+  recorded_at: Mon, 29 Apr 2024 08:36:33 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/ws_rekognition_detect_moderation_labels_status.yml
+++ b/spec/fixtures/vcr_cassettes/ws_rekognition_detect_moderation_labels_status.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.uploadcare.com/addons/aws_rekognition_detect_moderation_labels/execute/status/?request_id=0f4598dd-d168-4272-b49e-e7f9d2543542
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/vnd.uploadcare-v0.7+json
+      User-Agent:
+      - UploadcareRuby/4.4.1/demopublickey (Ruby/3.1.3)
+      Date:
+      - Mon, 29 Apr 2024 08:39:24 GMT
+      Authorization:
+      - Uploadcare demopublickey:a21a293522d88dbc4ff6d6248c559564f62354a6
+      Connection:
+      - close
+      Host:
+      - api.uploadcare.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Apr 2024 08:39:25 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '21'
+      Connection:
+      - close
+      Server:
+      - nginx
+      Vary:
+      - Accept
+      - Accept-Encoding
+      Warning:
+      - '199 Miscellaneous warning: You are using the demo project'
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Uploadcare-Request-Id:
+      - af3dbc6d-30c8-4fa3-b4f8-68bcb7295728
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: '{"status": "done"}'
+  recorded_at: Mon, 29 Apr 2024 08:39:25 GMT
+recorded_with: VCR 6.2.0

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require 'api_struct'
 require 'uploadcare'
 require 'action_view'
 require 'ostruct'
+require_relative 'support/stub_config_keys'
 
 Dir[File.expand_path(File.join(File.dirname(__FILE__), 'support', '**', '*.rb'))].sort.each { |f| require f }
 
@@ -25,4 +26,18 @@ RSpec.configure do |config|
   end
 
   config.include ActionView::Helpers, type: :helper
+
+  # Stub config keys for specs in the following directories
+  # spec/uploadcare/rails/api, spec/uploadcare/rails/objects
+  #
+  # Add metadata for the directories
+  # (Ref: https://www.rubydoc.info/gems/rspec-core/RSpec%2FCore%2FConfiguration:define_derived_metadata)
+  config.define_derived_metadata(file_path: %r{/spec/uploadcare/rails/api|objects/}) do |metadata|
+    metadata[:type] = :stub_config_keys
+  end
+
+  # Use the metadata to include the mod only for the specs from the directories
+  # (Ref: https://www.rubydoc.info/gems/rspec-core/RSpec%2FCore%2FConfiguration:include)
+  config.include StubConfigKeys, type: :stub_config_keys
+  # End stub config keys for specs
 end

--- a/spec/support/stub_config_keys.rb
+++ b/spec/support/stub_config_keys.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module StubConfigKeys
+  extend RSpec::SharedContext
+
+  before do
+    allow(Uploadcare.config).to receive_message_chain(:public_key).and_return('demopublickey')
+    allow(Uploadcare.config).to receive_message_chain(:secret_key).and_return('demosecretkey')
+  end
+end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -6,6 +6,8 @@ require 'vcr'
 VCR.configure do |config|
   config.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
   config.hook_into :webmock
+  config.filter_sensitive_data('<uploadcare_private_key>') { 'demopublickey' }
+  config.filter_sensitive_data('<uploadcare_secret_key>') { 'demosecretkey' }
   config.before_record do |i|
     if i.request.body && i.request.body.size > 1024 * 1024
       i.request.body = "Big string (#{i.request.body.size / (1024 * 1024)}) MB"

--- a/spec/uploadcare/rails/api/rest/addons_api_spec.rb
+++ b/spec/uploadcare/rails/api/rest/addons_api_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'uploadcare/rails/api/rest/addons_api'
+
+module Uploadcare
+  module Rails
+    module Api
+      module Rest
+        RSpec.describe AddonsApi do
+          subject { Uploadcare::AddonsApi }
+
+          context 'when checking methods' do
+            it 'responds to expected REST methods' do
+              %i[virus_scan virus_scan_status rekognition_detect_labels rekognition_detect_labels_status
+                 remove_bg remove_bg_status rekognition_detect_moderation_labels
+                 rekognition_detect_moderation_labels_status].each do |method|
+                expect(subject).to respond_to(method)
+              end
+            end
+          end
+
+          context 'when sending requests' do
+            it 'scans the file for viruses' do
+              VCR.use_cassette('uc_clamav_virus_scan') do
+                uuid = 'ff4d3d37-4de0-4f6d-a7db-8cdabe7fc768'
+                params = { purge_infected: true }
+                response = subject.virus_scan(uuid, params)
+                expect(response.request_id).to eq('34abf037-5384-4e38-bad4-97dd48e79acd')
+              end
+            end
+
+            it 'checking the status of a virus scanned file' do
+              VCR.use_cassette('uc_clamav_virus_scan_status') do
+                uuid = '34abf037-5384-4e38-bad4-97dd48e79acd'
+                response = subject.virus_scan_status(uuid)
+                expect(response.status).to eq('done')
+              end
+            end
+
+            it 'executes aws rekognition' do
+              VCR.use_cassette('ws_rekognition_detect_labels') do
+                uuid = 'ff4d3d37-4de0-4f6d-a7db-8cdabe7fc768'
+                response = subject.rekognition_detect_labels(uuid)
+                expect(response.request_id).to eq('0f4598dd-d168-4272-b49e-e7f9d2543542')
+              end
+            end
+
+            it 'checking the status of a recognized file' do
+              VCR.use_cassette('ws_rekognition_detect_labels_status') do
+                uuid = '0f4598dd-d168-4272-b49e-e7f9d2543542'
+                response = subject.rekognition_detect_labels_status(uuid)
+                expect(response.status).to eq('done')
+              end
+            end
+
+            it 'executes background image removal' do
+              VCR.use_cassette('remove_bg') do
+                uuid = 'ff4d3d37-4de0-4f6d-a7db-8cdabe7fc768'
+                params = { crop: true, type_level: '2' }
+                response = subject.remove_bg(uuid, params)
+                expect(response.request_id).to eq('c3446e41-9eb0-4301-aeb4-356d0fdcf9af')
+              end
+            end
+
+            it 'checking the status background image removal file' do
+              VCR.use_cassette('remove_bg_status') do
+                uuid = 'c3446e41-9eb0-4301-aeb4-356d0fdcf9af'
+                response = subject.remove_bg_status(uuid)
+                expect(response.status).to eq('done')
+                expect(response.result).to eq({ 'file_id' => 'bc37b996-916d-4ed7-b230-fa71a4290cb3' })
+              end
+            end
+
+            it 'executes aws rekognition moderation' do
+              VCR.use_cassette('ws_rekognition_detect_moderation_labels') do
+                uuid = 'ff4d3d37-4de0-4f6d-a7db-8cdabe7fc768'
+                response = subject.rekognition_detect_moderation_labels(uuid)
+                expect(response.request_id).to eq('0f4598dd-d168-4272-b49e-e7f9d2543542')
+              end
+            end
+
+            it 'checking the status of aws rekognition moderation recognized file' do
+              VCR.use_cassette('ws_rekognition_detect_moderation_labels_status') do
+                uuid = '0f4598dd-d168-4272-b49e-e7f9d2543542'
+                response = subject.rekognition_detect_moderation_labels_status(uuid)
+                expect(response.status).to eq('done')
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/uploadcare/rails/api/rest/group_api_spec.rb
+++ b/spec/uploadcare/rails/api/rest/group_api_spec.rb
@@ -10,13 +10,6 @@ module Uploadcare
         RSpec.describe GroupApi do
           subject { Uploadcare::GroupApi }
 
-          around do |example|
-            previous_value = Uploadcare.config.public_key
-            Uploadcare.config.public_key = 'demopublickey'
-            example.run
-            Uploadcare.config.public_key = previous_value
-          end
-
           context 'when checking methods' do
             it 'responds to expected REST methods' do
               %i[get_groups get_group store_group create_group].each do |method|


### PR DESCRIPTION
## Description

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->


## Checklist

- [x] Tests (if applicable)
- [x] Documentation (if applicable)
- [x] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced AWS Rekognition Moderation Add-On for detecting moderation labels in images.
- **Documentation**
	- Updated README to reflect new AWS Rekognition Moderation capabilities.
- **Tests**
	- Added various test cases and fixtures for new and existing functionalities, including AWS Rekognition and virus scanning.
- **Refactor**
	- Implemented sensitive data filtering within VCR configurations for enhanced security.
- **Chores**
	- Adjusted HTTP request details in VCR cassettes to align with current API specifications and security practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->