### PR TITLE
Fix gem version to 3.4.2

### DIFF
--- a/lib/uploadcare/rails/version.rb
+++ b/lib/uploadcare/rails/version.rb
@@ -2,6 +2,6 @@
 
 module Uploadcare
   module Rails
-    VERSION = '3.4.1'
+    VERSION = '3.4.2'
   end
 end


### PR DESCRIPTION
## Description

I forgot to update this to 3.4.2 in https://github.com/uploadcare/uploadcare-rails/pull/141 :-( 

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated version number from `3.4.1` to `3.4.2` for improved compatibility and minor enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->