### PR TITLE
Use discourse/publish-rubygems-action@main for gem publish

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -13,8 +13,10 @@ jobs:
 
       - name: Release Gem
         if: contains(github.ref, 'refs/tags/v')
-        uses: cadwallion/publish-rubygems-action@master
+        uses: discourse/publish-rubygems-action@main
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}
           RELEASE_COMMAND: rake release
+          GIT_EMAIL: hello@uploadcare.com
+          GIT_NAME: Uploadcare Developers


### PR DESCRIPTION
## Description

- Use discourse/publish-rubygems-action@main for gem publish as it seems to be a better-maintained version. 
- Also, add GIT identities for the same


## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the RubyGems publishing action to improve reliability.
  - Set environment variables for commit identity (`GIT_EMAIL` and `GIT_NAME`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->