### PR TITLE
For `Uploadcare::ConversionApi` added `get_document_conversion_formats_info` method to get the possible document conversion formats.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,3 +34,7 @@ Style/OpenStructUse:
     - 'spec/uploadcare/rails/active_record/mount_uploadcare_file_spec.rb'
     - 'spec/uploadcare/rails/active_record/mount_uploadcare_group_spec.rb'
     - 'spec/uploadcare/rails/objects/file_spec.rb'
+
+Metrics/ModuleLength:
+  Exclude:
+    - 'spec/**/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based now on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+* For `Uploadcare::ConversionApi` added `get_document_conversion_formats_info` method to get the possible document conversion formats.
+
 ## 3.4.2 — 2024-05-11
 
 ### Added

--- a/lib/uploadcare/rails/api/rest/conversion_api.rb
+++ b/lib/uploadcare/rails/api/rest/conversion_api.rb
@@ -21,6 +21,12 @@ module Uploadcare
               Uploadcare::VideoConverter.status(token)
             end
 
+            # Conversion formats info
+            # @see https://uploadcare.com/api-refs/rest-api/v0.7.0/#tag/Conversion/operation/documentConvertInfo
+            def get_document_conversion_formats_info(uuid)
+              Uploadcare::DocumentConverter.info(uuid)
+            end
+
             # Converts documents
             # @see https://uploadcare.com/api-refs/rest-api/v0.7.0/#operation/documentConvert
             def convert_document(document_params, options = {})

--- a/spec/fixtures/vcr_cassettes/conversion_api_get_document_conversion_formats_info.yml
+++ b/spec/fixtures/vcr_cassettes/conversion_api_get_document_conversion_formats_info.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.uploadcare.com/convert/document/b3b32bcb-9bd8-4ee2-a4df-95bcee96b47e/
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/vnd.uploadcare-v0.7+json
+      User-Agent:
+      - UploadcareRuby/4.4.1/<uploadcare_public_key> (Ruby/3.3.0)
+      Date:
+      - Wed, 29 May 2024 14:11:11 GMT
+      Authorization:
+      - Uploadcare <uploadcare_public_key>:4cf818d83c516d3bfb55f9b95aab2feeda4028af
+      Connection:
+      - close
+      Host:
+      - api.uploadcare.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 29 May 2024 14:11:12 GMT
+      Content-Type:
+      - application/vnd.uploadcare-v0.7+json
+      Content-Length:
+      - '280'
+      Connection:
+      - close
+      Server:
+      - nginx
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Vary:
+      - Accept
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Uploadcare-Request-Id:
+      - fdba08c5-f0dc-4b91-a3e0-48ff0255c367
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"error":null,"format":{"name":"jpg","conversion_formats":[{"name":"avif"},{"name":"bmp"},{"name":"gif"},{"name":"ico"},{"name":"pcx"},{"name":"pdf"},{"name":"png"},{"name":"ps"},{"name":"svg"},{"name":"tga"},{"name":"thumbnail"},{"name":"tiff"},{"name":"wbmp"},{"name":"webp"}]}}'
+  recorded_at: Wed, 29 May 2024 14:11:12 GMT
+recorded_with: VCR 6.2.0

--- a/spec/uploadcare/rails/api/rest/conversion_api_spec.rb
+++ b/spec/uploadcare/rails/api/rest/conversion_api_spec.rb
@@ -14,7 +14,13 @@ module Uploadcare
 
           context 'when checking methods' do
             it 'responds to expected REST methods' do
-              %i[convert_video get_video_conversion_status convert_document get_document_conversion_status].each do |m|
+              %i[
+                convert_video
+                get_video_conversion_status
+                convert_document
+                get_document_conversion_status
+                get_document_conversion_formats_info
+              ].each do |m|
                 expect(subject).to respond_to(m)
               end
             end
@@ -86,6 +92,19 @@ module Uploadcare
                     response = subject.get_document_conversion_status(token)
                     expect(response).to be_success
                     expect(response.success[:error]).to be_nil
+                  end
+                end
+
+                it 'gets document conversion formats info' do
+                  VCR.use_cassette('conversion_api_get_document_conversion_formats_info') do
+                    uuid = 'b3b32bcb-9bd8-4ee2-a4df-95bcee96b47e'
+                    response = subject.get_document_conversion_formats_info(uuid)
+                    expect(response).to be_success
+                    expect(response.success[:error]).to be_nil
+                    expect(response.success[:format][:name]).to be_a(String)
+                    conversion_formats = response.success[:format][:conversion_formats]
+                    expect(conversion_formats).to be_a(Array)
+                    expect(conversion_formats.first[:name]).to be_a(String)
                   end
                 end
               end

--- a/uploadcare-rails.gemspec
+++ b/uploadcare-rails.gemspec
@@ -44,5 +44,5 @@ Gem::Specification.new do |gem|
 
   gem.version = Uploadcare::Rails::VERSION
   gem.add_dependency 'rails', '>= 6'
-  gem.add_dependency 'uploadcare-ruby', '>= 4.4.1'
+  gem.add_dependency 'uploadcare-ruby', '>= 4.4.2'
 end


### PR DESCRIPTION
## Description

For `Uploadcare::ConversionApi` added `get_document_conversion_formats_info` method to get the possible document conversion formats.


## Checklist

- [x] Tests (if applicable)
- [x] Documentation (if applicable)
- [x] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added functionality to retrieve document conversion format information using the Uploadcare API.

- **Chores**
  - Updated `uploadcare-ruby` dependency version from `4.4.1` to `4.4.2`.

- **Tests**
  - Added test cases for the new document conversion format retrieval method.

- **Style**
  - Excluded files under the `spec` directory from the `Metrics/ModuleLength` RuboCop rule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->