### PR TITLE
Fix Rails engine helper loading

### DIFF
--- a/lib/uploadcare/rails/engine.rb
+++ b/lib/uploadcare/rails/engine.rb
@@ -22,8 +22,8 @@ module Uploadcare
           require "uploadcare/rails/internal/uploader_field_helpers"
           require "uploadcare/rails/action_view/form_builder"
 
-          ActionView::Base.include Uploadcare::Rails::ActionView::UploadcareIncludeTags
-          ActionView::Base.include Uploadcare::Rails::Internal::UploaderFieldHelpers
+          ::ActionView::Base.include Uploadcare::Rails::ActionView::UploadcareIncludeTags
+          ::ActionView::Base.include Uploadcare::Rails::Internal::UploaderFieldHelpers
         end
 
         ActiveSupport.on_load :active_record do
@@ -77,6 +77,8 @@ module Uploadcare
       end
 
       def merge_uploadcare_settings!(target, source)
+        return if source.nil?
+
         source.each do |key, value|
           target[key] = value
         end

--- a/spec/uploadcare/rails/engine_spec.rb
+++ b/spec/uploadcare/rails/engine_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Uploadcare::Rails::Engine do
+  describe 'configuration loading' do
+    let(:target) { ActiveSupport::OrderedOptions.new }
+
+    it 'ignores missing environment settings from config_for' do
+      expect do
+        described_class.instance.send(:merge_uploadcare_settings!, target, nil)
+      end.not_to raise_error
+
+      expect(target.to_h).to eq({})
+    end
+
+    it 'merges environment settings into the Rails config' do
+      described_class.instance.send(
+        :merge_uploadcare_settings!,
+        target,
+        { public_key: 'public', secret_key: 'secret' }
+      )
+
+      expect(target.public_key).to eq('public')
+      expect(target.secret_key).to eq('secret')
+    end
+  end
+end


### PR DESCRIPTION
Fixes Rails engine helper loading by qualifying `::ActionView::Base` and hardens Uploadcare config loading when `config_for` returns nil.

Repro with `uploadcare-rails` 5.0.0:

```sh
rails new uploadcare_repro --skip-javascript
cd uploadcare_repro
bundle add uploadcare-rails --version 5.0.0
bin/rails g uploadcare_config
bin/rails runner 'ApplicationController.helpers.uploadcare_include_tag'
```

Current result: `uninitialized constant Uploadcare::Rails::ActionView::Base`.

Tested with the Rails 7.2 spec suite in Docker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Engine configuration now gracefully handles missing configuration without errors.
  * Improved ActionView helper integration stability.

* **Tests**
  * Added comprehensive test coverage for engine configuration loading and settings merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->